### PR TITLE
chore: make dependabot respect version ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
Dependabot is currently raising PRs to bump to the latest version of a dependency, independent of the version range set in the package.json. This PR should change it to respect the version ranges coming from the package.json, so we can decide on major bumps during development and have the bot to keep our dependencies up-to-date within the "developer approved" range.