### PR TITLE
[AB#40100] feat: build and run container as their native non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,14 @@ COPY ["./nginx/mosaic-fe-samples.conf", "/etc/nginx/conf.d/"]
 # Copy build-artifact
 COPY ["./build", "/usr/share/nginx/html/"]
 
+RUN chown -R nginx:nginx /usr/share/nginx && \
+    chown -R nginx:nginx /etc/nginx && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/run/nginx.pid
+
+USER nginx
+
 CMD ["nginx", "-g", "daemon off;"]
 
-EXPOSE 80/tcp
+EXPOSE 8080/tcp

--- a/nginx/mosaic-fe-samples.conf
+++ b/nginx/mosaic-fe-samples.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
 
     location / {
         root   /usr/share/nginx/html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,5 +25,9 @@ http {
 
     gzip  on;
 
+    server {
+      listen 8081;
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
- Frontend UIs (nginx):
   - container is run as `nginx(101)` user and `nginx(101)` group.
   - ownership of below directories/files are given to `nginx` user and group.
     - `/usr/share/nginx`
     - `/etc/nginx`
     - `/var/cache/nginx`
     - `/var/run/nginx.pid`
  - container binds to port `8080` instead of previous/default `80`. this is because port `80` is treated as a special port that requires elevated privileges/root.