### PR TITLE
[AB#40100] fix: use 1000 as the gid and uid of container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@
 
 FROM nginx:stable-alpine
 
+# With SDU/Hosting, we expect the containers to have `1000` as the user's ID and GID.
+# While we use the inbuilt `nginx` user to run the server, its id and gid are 101, so we change it here.
+RUN echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories && \
+    apk --no-cache add shadow && \
+    groupmod -g 1000 nginx && \
+    usermod -u 1000 -g 1000 nginx && \
+    apk del shadow
+
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy Nginx configuration files


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
- As a standard, use `1000` as the `uid` and `gid` of the user that runs the main process inside the container.