### PR TITLE
[AB#39575] Add channels in catalog service queries

### DIFF
--- a/src/scenarios/catalog-consumption/GetSingleItem/graphql-documents.ts
+++ b/src/scenarios/catalog-consumption/GetSingleItem/graphql-documents.ts
@@ -16,6 +16,28 @@ export const getAllItemsQuery = gql`
       cast
       released
       tags
+      images {
+        nodes {
+          id
+          type
+          path
+        }
+      }
+      videos {
+        nodes {
+          id
+          dashManifest
+          hlsManifest
+          cuePoints {
+            nodes {
+              id
+              cuePointTypeKey
+              timeInSeconds
+              value
+            }
+          }
+        }
+      }
     }
     tvshow(id: $id) {
       id
@@ -31,6 +53,13 @@ export const getAllItemsQuery = gql`
       cast
       released
       tags
+      images {
+        nodes {
+          id
+          type
+          path
+        }
+      }
       seasons {
         nodes {
           id
@@ -61,6 +90,13 @@ export const getAllItemsQuery = gql`
       cast
       released
       tags
+      images {
+        nodes {
+          id
+          type
+          path
+        }
+      }
     }
     episode(id: $id) {
       id
@@ -76,6 +112,35 @@ export const getAllItemsQuery = gql`
       cast
       released
       tags
+      images {
+        nodes {
+          id
+          type
+          path
+        }
+      }
+      videos {
+        nodes {
+          id
+          dashManifest
+          hlsManifest
+          cuePoints {
+            nodes {
+              id
+              cuePointTypeKey
+              timeInSeconds
+              value
+            }
+          }
+        }
+      }
+    }
+    channel(id: $id) {
+      id
+      title
+      hlsStreamUrl
+      description
+      dashStreamUrl
     }
   }
 `;

--- a/src/scenarios/catalog-consumption/ListCatalogItems/ListCatalogItems.tsx
+++ b/src/scenarios/catalog-consumption/ListCatalogItems/ListCatalogItems.tsx
@@ -10,6 +10,7 @@ import {
 } from 'semantic-ui-react';
 import { getApolloClient } from '../../../apollo-client';
 import {
+  getAllChannelsQuery,
   getAllItemsQuery,
   getAllMoviesQuery,
   getAllTvShowsQuery,
@@ -100,6 +101,17 @@ export const ListCatalogItems: React.FC = () => {
           }}
         >
           List All TV Shows
+        </Button>
+
+        <Divider />
+
+        <Button
+          primary
+          onClick={async () => {
+            fetchAndLogCatalogItems(getAllChannelsQuery);
+          }}
+        >
+          List All Channels
         </Button>
       </Segment>
     </>

--- a/src/scenarios/catalog-consumption/ListCatalogItems/graphql-documents.ts
+++ b/src/scenarios/catalog-consumption/ListCatalogItems/graphql-documents.ts
@@ -28,6 +28,15 @@ export const getAllItemsQuery = gql`
         }
       }
     }
+    channels {
+      nodes {
+        id
+        title
+        description
+        dashStreamUrl
+        hlsStreamUrl
+      }
+    }
   }
 `;
 
@@ -62,6 +71,20 @@ export const getAllTvShowsQuery = gql`
             }
           }
         }
+      }
+    }
+  }
+`;
+
+export const getAllChannelsQuery = gql`
+  query GetAllChannels {
+    channels {
+      nodes {
+        id
+        title
+        description
+        dashStreamUrl
+        hlsStreamUrl
       }
     }
   }


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description
The catalog service scenarios now also query the published channels.
In addition, they now also query more details about the entities (images, videos, cue points)
