### PR TITLE
[AB#40732] feat: :technologist: introduce user-auth-proxy to support localhost development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,4 @@
 PORT=3000
+
+USER_AUTH_BASE_URL=https://user-auth.service.eu.axinom.net
+USER_AUTH_LOCAL_PROXY_PORT=11105

--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ libraries shall be used.
 # Running the Project
 
 - Run `yarn` to install dependencies
-- Copy `.env.template` into `.env`, and change the PORT number as needed
+- Copy `.env.template` into `.env`, and change the values if needed
 - Run `yarn dev` to start running the project in watch mode
+- Run `yarn util:start-proxy` to start a `localhost` proxy to the
+  `Mosaic User Service` upstream
+  - Ensure to set/update the URL for `User Auth Base URL` in your
+    `Mosaic Frontend Samples` profile to use the proxy endpoint for requests
 
 # Building for Production
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "react-scripts test",
     "test:ci": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "util:update-mosaic-packages": "ts-node ./scripts/update-mosaic-packages.ts"
+    "util:load-vars": "env-cmd -f ./.env",
+    "util:update-mosaic-packages": "ts-node ./scripts/update-mosaic-packages.ts",
+    "util:start-proxy": "yarn util:load-vars ts-node ./scripts/proxy-server.ts"
   },
   "dependencies": {
     "@apollo/client": "^3.2.5",
@@ -33,8 +35,10 @@
     "@types/node": "^18",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^17.0.1",
+    "env-cmd": "^10.1.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "http-proxy": "^1.18.1",
     "prettier": "^2.3.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/scripts/proxy-server.ts
+++ b/scripts/proxy-server.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+import http from 'http';
+import httpProxy from 'http-proxy';
+
+async function startProxy(): Promise<void> {
+  const proxyPort = process.env.USER_AUTH_LOCAL_PROXY_PORT;
+  const upstreamTarget = process.env.USER_AUTH_BASE_URL;
+
+  if (!proxyPort || !upstreamTarget) {
+    console.log(
+      `Required environment variables to start the Proxy Server are not set.
+Please ensure the '.env' file contains all entries defined in the '.env.template' file.`,
+    );
+
+    process.exit(1);
+  }
+
+  const proxy = httpProxy.createProxyServer();
+  const server = http.createServer((req, res) => {
+    proxy.web(
+      req,
+      res,
+      {
+        target: upstreamTarget,
+        xfwd: true,
+        changeOrigin: true,
+      },
+      (error) => {
+        console.log({
+          context: 'user-auth-proxy',
+          message: 'An exception occurred while proxying.',
+          details: error,
+        });
+      },
+    );
+  });
+
+  server.on('listening', () => {
+    console.log(
+      `\n> user-auth-proxy running
+      http://localhost:${proxyPort} -> ${upstreamTarget}`,
+    );
+  });
+
+  server.listen(proxyPort);
+}
+
+startProxy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,6 +4779,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: d7b9913ff92cae20cb577a4ac6fcc121bd6223319e54a40f51a14740a681ad5c574fd29a57da478a5f234a6fa6c52cbf0b7c641353e03c648b1ae85ba670b977
+  languageName: node
+  linkType: hard
+
 "commander@npm:^7.2.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
@@ -4966,7 +4973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -5830,6 +5837,18 @@ __metadata:
   version: 4.4.0
   resolution: "entities@npm:4.4.0"
   checksum: 84d250329f4b56b40fa93ed067b194db21e8815e4eb9b59f43a086f0ecd342814f6bc483de8a77da5d64e0f626033192b1b4f1792232a7ea6b970ebe0f3187c2
+  languageName: node
+  linkType: hard
+
+"env-cmd@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "env-cmd@npm:10.1.0"
+  dependencies:
+    commander: ^4.0.0
+    cross-spawn: ^7.0.0
+  bin:
+    env-cmd: bin/env-cmd.js
+  checksum: efef55074250f14cfc0b80c98dd98f1f056a80e1f3c7db14097ceefdd2d56c766bbb83b54c22932112707f41b36ce2e923f8015d69e62a75c12d98640b972e75
   languageName: node
   linkType: hard
 
@@ -9513,11 +9532,13 @@ __metadata:
     "@types/node": ^18
     "@types/react": ^17.0.1
     "@types/react-dom": ^17.0.1
+    env-cmd: ^10.1.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^4.0.0
     graphql: ^16.6.0
     graphql-tag: ^2.11.0
     graphql-ws: ^5.5.0
+    http-proxy: ^1.18.1
     i18n-iso-countries: ^7.6.0
     prettier: ^2.3.2
     react: ^17.0.1


### PR DESCRIPTION
- introduced a `yarn util:start-proxy` script to start a localhost proxy that routes traffic to User Service
- this shall help to avoid cross-domain cookie issues during local development
- README.md is updated to reflect the usage