### PR TITLE
[AB#40647] feat: adding support for channel playout & event listeners that report SCTE events on playout scenarios

### DIFF
--- a/src/scenario-registry.ts
+++ b/src/scenario-registry.ts
@@ -295,7 +295,6 @@ export const scenarios = [
     displayOrder: 8,
     rootComponent: DataRemove,
   },
-
 ] as const;
 
 export type ScenarioKey = typeof scenarios[number]['shortId'];

--- a/src/scenarios/video-playback/PlayProtectedVideo/graphql-documents.ts
+++ b/src/scenarios/video-playback/PlayProtectedVideo/graphql-documents.ts
@@ -76,6 +76,16 @@ export const getEpisodeVideosQuery = gql`
   }
 `;
 
+export const getChannelVideosQuery = gql`
+  query GetChannelVideos($id: String!) {
+    channel(id: $id) {
+      title
+      hlsStreamUrl
+      dashStreamUrl
+    }
+  }
+`;
+
 export const getEntitlementMessageQuery = gql`
   query GetEntitlementMessage($input: EntitlementInput!) {
     entitlement(input: $input) {

--- a/src/scenarios/video-playback/PlayUnprotectedVideo/PlayUnprotectedVideo.tsx
+++ b/src/scenarios/video-playback/PlayUnprotectedVideo/PlayUnprotectedVideo.tsx
@@ -4,7 +4,7 @@ import {
   VariableSearch,
 } from '@axinom/mosaic-fe-samples-host';
 import { DocumentNode } from 'graphql';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Container,
   Divider,
@@ -19,6 +19,7 @@ import 'shaka-player-react/dist/controls.css';
 import { getApolloClient } from '../../../apollo-client';
 import { ScenarioKey } from '../../../scenario-registry';
 import {
+  getChannelVideosQuery,
   getEpisodeVideosQuery,
   getMovieVideosQuery,
   getSeasonVideosQuery,
@@ -44,6 +45,49 @@ export const PlayUnprotectedVideo: React.FC = () => {
   // TODO: Define types for ShakaPlayer or use a different player.
   const shakaController = useRef<any>();
 
+  useEffect(() => {
+    const player = shakaController.current?.videoElement;
+
+    if (player) {
+      // Listen for error events.
+      const errorHandler = (event: { detail: any }): void => {
+        logger.error(
+          'An error occurred while attempting to play the video.',
+          'Please refer the error code displayed below in Shaka Player error documentation at: https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html',
+          event.detail,
+        );
+      };
+      player.addEventListener('error', errorHandler);
+
+      // Listen to possible SCTE events.
+      const timelineregionenterHandler = (event: any): void => {
+        logger.log('timelineregionenter event detected', event.detail);
+      };
+      player.addEventListener(
+        'timelineregionenter',
+        timelineregionenterHandler,
+      );
+
+      const timelineregionexitHandler = (event: any): void => {
+        logger.log('timelineregionexit event detected', event.detail);
+      };
+      player.addEventListener('timelineregionexit', timelineregionexitHandler);
+
+      return () => {
+        // Remove event listeners.
+        player.removeEventListener('error', errorHandler);
+        player.removeEventListener(
+          'timelineregionenter',
+          timelineregionenterHandler,
+        );
+        player.removeEventListener(
+          'timelineregionexit',
+          timelineregionexitHandler,
+        );
+      };
+    }
+  }, [logger, shakaController]);
+
   const resetVideoPlayback = async (): Promise<void> => {
     const { player } = shakaController.current;
     await player.unload();
@@ -53,14 +97,34 @@ export const PlayUnprotectedVideo: React.FC = () => {
     await resetVideoPlayback();
 
     let query: DocumentNode | undefined = undefined;
+    let resultTransformer: (result: any) => Video[] = (r) => r;
+
     if (entityId.startsWith('movie-')) {
       query = getMovieVideosQuery;
+      resultTransformer = (result: any) => result.data.movie?.videos?.nodes;
     } else if (entityId.startsWith('tvshow-')) {
       query = getTvShowVideosQuery;
+      resultTransformer = (result: any) => result.data.tvshow?.videos?.nodes;
     } else if (entityId.startsWith('season-')) {
       query = getSeasonVideosQuery;
+      resultTransformer = (result: any) => result.data.season?.videos?.nodes;
     } else if (entityId.startsWith('episode-')) {
       query = getEpisodeVideosQuery;
+      resultTransformer = (result: any) => result.data.episode?.videos?.nodes;
+    } else if (entityId.startsWith('channel-')) {
+      query = getChannelVideosQuery;
+      resultTransformer = (result: any) =>
+        !result.data?.channel
+          ? []
+          : [
+              {
+                id: entityId,
+                title: result.data.channel.title,
+                type: 'channel',
+                dashManifest: result.data.channel.dashStreamUrl,
+                hlsManifest: result.data.channel.hlsStreamUrl,
+              },
+            ];
     }
 
     if (query !== undefined) {
@@ -82,11 +146,10 @@ export const PlayUnprotectedVideo: React.FC = () => {
         if (result.errors) {
           logger.error(result.errors);
         } else {
-          const mediaEntity = result.data[Object.keys(result.data)[0]];
-          if (mediaEntity !== null) {
-            setVideos(mediaEntity.videos.nodes);
-          } else {
-            setVideos([]);
+          const videos = resultTransformer(result);
+          setVideos(videos ?? []);
+
+          if (videos.length === 0) {
             logger.error('Invalid entity ID.');
           }
         }
@@ -111,18 +174,9 @@ export const PlayUnprotectedVideo: React.FC = () => {
 
     if (currentVideoId !== undefined) {
       const currentVideo = videos.find((video) => video.id === currentVideoId);
+
       if (currentVideo !== undefined) {
         const { player, videoElement } = shakaController.current;
-
-        // Listen for error events.
-        // TODO: this should be done only once instead on every time 'Play Video' button is pressed.
-        player.addEventListener('error', (event: { detail: any }) =>
-          logger.error(
-            'An error occurred while attempting to play the video.',
-            'Please refer the error code displayed below in Shaka Player error documentation at: https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html',
-            event.detail,
-          ),
-        );
 
         try {
           await player.load(

--- a/src/scenarios/video-playback/PlayUnprotectedVideo/graphql-documents.ts
+++ b/src/scenarios/video-playback/PlayUnprotectedVideo/graphql-documents.ts
@@ -75,3 +75,13 @@ export const getEpisodeVideosQuery = gql`
     }
   }
 `;
+
+export const getChannelVideosQuery = gql`
+  query GetChannelVideos($id: String!) {
+    channel(id: $id) {
+      title
+      hlsStreamUrl
+      dashStreamUrl
+    }
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4501,9 +4501,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001426":
-  version: 1.0.30001436
-  resolution: "caniuse-lite@npm:1.0.30001436"
-  checksum: 7928ac7d93741a81b3005ca4623b133e7d790828be70b26ee55e4860facc59bc344f4092e20034981070a4714f70814c8be4929be4b22728031784f267f69099
+  version: 1.0.30001517
+  resolution: "caniuse-lite@npm:1.0.30001517"
+  checksum: e4e87436ae1c4408cf4438aac22902b31eb03f3f5bad7f33bc518d12ffb35f3fd9395ccf7efc608ee046f90ce324ec6f7f26f8a8172b8c43c26a06ecee612a29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the capability to playout channels by providing the channel entity id.
It also adds event listeners to the playout scenarios that will report timeline events.
These handlers will be called, when a stream contains SCTE events, for example, a non-ad-inserted FAST channel stream.