### PR TITLE
[AB#39575] Adding support for channel images

### DIFF
--- a/src/scenarios/catalog-consumption/GetSingleItem/graphql-documents.ts
+++ b/src/scenarios/catalog-consumption/GetSingleItem/graphql-documents.ts
@@ -141,6 +141,13 @@ export const getAllItemsQuery = gql`
       hlsStreamUrl
       description
       dashStreamUrl
+      images {
+        nodes {
+          id
+          path
+          type
+        }
+      }
     }
   }
 `;

--- a/src/scenarios/image/ImagePreview/ImagePreview.tsx
+++ b/src/scenarios/image/ImagePreview/ImagePreview.tsx
@@ -16,6 +16,7 @@ import {
 } from 'semantic-ui-react';
 import { getApolloClient } from '../../../apollo-client';
 import {
+  getChannelImagesQuery,
   getEpisodeImagesQuery,
   getMovieImagesQuery,
   getSeasonImagesQuery,
@@ -56,6 +57,8 @@ export const ImagePreview: React.FC = () => {
       query = getSeasonImagesQuery;
     } else if (entityId.startsWith('episode-')) {
       query = getEpisodeImagesQuery;
+    } else if (entityId.startsWith('channel-')) {
+      query = getChannelImagesQuery;
     }
 
     if (query !== undefined) {

--- a/src/scenarios/image/ImagePreview/graphql-documents.ts
+++ b/src/scenarios/image/ImagePreview/graphql-documents.ts
@@ -67,3 +67,20 @@ export const getEpisodeImagesQuery = gql`
     }
   }
 `;
+
+export const getChannelImagesQuery = gql`
+  query GetChannelImages($id: String!) {
+    channel(id: $id) {
+      title
+      images {
+        nodes {
+          id
+          width
+          height
+          path
+          type
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
- The `Get Single Item` scenario now returns the images for Channels
- The `Image Preview` scenario now supports Channel IDs as well