### PR TITLE
[AB#42020] - Adjust "List Subscription Plans Anonymously" scenario to use lib to get application token

### DIFF
--- a/src/scenario-registry.ts
+++ b/src/scenario-registry.ts
@@ -25,7 +25,7 @@ import {
 import { ImagePreview } from './scenarios/image';
 import {
   ListSubscriptionPlansForUser,
-  ListSubscriptionPlansAnonymously,
+  ListSubscriptionPlansAnonymouslyContainer,
   ListUserSubscriptions,
   UnsubscribeFromSubscriptionPlanPayPal,
   ListUserPaymentHistory,
@@ -191,7 +191,7 @@ export const scenarios = [
     shortId: 'list-subscription-plans-anonymously',
     displayName: 'List Subscription Plans Anonymously',
     displayOrder: 1,
-    rootComponent: ListSubscriptionPlansAnonymously,
+    rootComponent: ListSubscriptionPlansAnonymouslyContainer,
   },
   {
     groupName: 'Billing & Monetization',

--- a/src/scenarios/billing/ListSubscriptionPlansAnonymously/ListSubscriptionPlansAnonymously.tsx
+++ b/src/scenarios/billing/ListSubscriptionPlansAnonymously/ListSubscriptionPlansAnonymously.tsx
@@ -71,13 +71,6 @@ export const ListSubscriptionPlansAnonymously: React.FC = () => {
   const [selectedCountry, setSelectedCountry] = useState<string>('');
   const { authenticateEndUserApplication } = useUserService();
 
-  const authenticateEndUserApplicationRequest = {
-    tenantId: activeProfile.tenantId,
-    environmentId: activeProfile.environmentId,
-    applicationId: activeProfile.applicationId,
-    applicationKey: activeProfile.applicationKey,
-  };
-
   // Get all country names and country codes by ISO 3166-1 and stored in the array
   countries.registerLocale(en);
 
@@ -92,6 +85,13 @@ export const ListSubscriptionPlansAnonymously: React.FC = () => {
 
   const fetchApplicationToken = async (): Promise<void> => {
     try {
+      const authenticateEndUserApplicationRequest = {
+        tenantId: activeProfile.tenantId,
+        environmentId: activeProfile.environmentId,
+        applicationId: activeProfile.applicationId,
+        applicationKey: activeProfile.applicationKey,
+      };
+
       const appTokenResult = await authenticateEndUserApplication(
         authenticateEndUserApplicationRequest,
       );


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [x] appropriate labels for the PR applied

## Description

When click on the 'Fetch Application Token' button in `List Subscription Plans Anonymously` scenario, application token will get by calling to 'authenticateEndUserApplication' method in user-auth lib.
