### PR TITLE
[AB#54551] [AB#54554] [AB#54681] feat: add device authorization sample scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prompts": "^2.4.2",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",
+    "react-qr-code": "^2.0.15",
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.5",
-    "@axinom/mosaic-fe-samples-host": "0.40.0",
-    "@axinom/mosaic-user-auth": "0.26.0",
+    "@axinom/mosaic-fe-samples-host": "0.43.0-rc.7",
+    "@axinom/mosaic-user-auth": "0.29.0-rc.7",
+    "@axinom/mosaic-user-auth-utils": "0.9.0-rc.0",
     "@babel/core": "^7.16.0",
     "@paypal/paypal-js": "^5.1.4",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/src/scenario-registry.ts
+++ b/src/scenario-registry.ts
@@ -3,6 +3,7 @@ import {
   ListCatalogItems,
 } from './scenarios/catalog-consumption';
 import {
+  DeviceAuthorizationContainer,
   RenewUserTokenContainer,
   ResetPasswordWithAxAuthContainer,
   ShowUserInfoContainer,
@@ -82,9 +83,16 @@ export const scenarios = [
   },
   {
     groupName: 'User Authentication',
+    shortId: 'device-authorization',
+    displayName: 'Device Authorization (Smart-TV Sign-In)',
+    displayOrder: 7,
+    rootComponent: DeviceAuthorizationContainer,
+  },
+  {
+    groupName: 'User Authentication',
     shortId: 'sign-out-user',
     displayName: 'Sign-Out User',
-    displayOrder: 7,
+    displayOrder: 8,
     rootComponent: SignOutUserContainer,
   },
 

--- a/src/scenarios/user-authentication/DeviceAuthorization/DeviceAuthorization.tsx
+++ b/src/scenarios/user-authentication/DeviceAuthorization/DeviceAuthorization.tsx
@@ -1,0 +1,280 @@
+import {
+  useScenarioHost,
+  VariableSearch,
+} from '@axinom/mosaic-fe-samples-host';
+import {
+  UserAuthConfig,
+  UserServiceConfig,
+  UserServiceProvider,
+  useUserService,
+} from '@axinom/mosaic-user-auth';
+import {
+  DeviceAuthorizationResponse,
+  DeviceAuthorizationResponseCode,
+  DevicePollResponseCode,
+} from '@axinom/mosaic-user-auth-utils';
+import { useRef, useState } from 'react';
+import QRCode from 'react-qr-code';
+import {
+  Button,
+  Container,
+  Divider,
+  Form,
+  Header,
+  Label,
+  Segment,
+} from 'semantic-ui-react';
+
+export const DeviceAuthorizationContainer: React.FC = () => {
+  const { activeProfile } = useScenarioHost();
+
+  const userAuthConfig: UserAuthConfig = {
+    userAuthBaseUrl: activeProfile.userAuthBaseURL,
+    tenantId: activeProfile.tenantId,
+    environmentId: activeProfile.environmentId,
+    applicationId: activeProfile.applicationId,
+  };
+
+  const userServiceConfig: UserServiceConfig = {
+    userServiceBaseUrl: activeProfile.userServiceBaseURL,
+  };
+
+  return (
+    <Segment basic>
+      <Header size="huge">Device Authorization (Smart-TV Sign-In)</Header>
+      <Header size="small">
+        Required Services:
+        <Label>ax-user-service</Label>
+        <Label>ax-auth-service</Label>
+      </Header>
+
+      <Divider />
+
+      <Container fluid>
+        <p>
+          Signs a user in on an input-constrained device (e.g. a Smart TV) using
+          the device authorization flow. The device shows a short code, the user
+          opens the verification URL on a phone or laptop and approves it, and
+          the device is then signed in.
+        </p>
+        <p>
+          Steps 1, 2 and 4 run on the device; step 3 runs on the second (already
+          signed-in) device. This one sample plays both roles; in production the
+          device is a NATIVE application and the activation page a separate WEB
+          application sharing the same user store. Step 3 needs a signed-in
+          user: run a Sign-In scenario first, then select its stored access
+          token in the field below.
+        </p>
+      </Container>
+
+      <Divider />
+
+      <UserServiceProvider
+        userAuthConfig={userAuthConfig}
+        userServiceConfig={userServiceConfig}
+      >
+        <DeviceAuthorization />
+      </UserServiceProvider>
+    </Segment>
+  );
+};
+
+const DeviceAuthorization: React.FC = () => {
+  const { logger } = useScenarioHost();
+  const {
+    requestDeviceAuthorization,
+    pollDeviceRefreshToken,
+    getDeviceAccessToken,
+    getDeviceVerification,
+    approveDevice,
+    denyDevice,
+  } = useUserService();
+
+  const [deviceLabel, setDeviceLabel] = useState('Living Room TV');
+  const [authorization, setAuthorization] = useState<
+    DeviceAuthorizationResponse | undefined
+  >();
+  const [isPolling, setIsPolling] = useState(false);
+  const [refreshToken, setRefreshToken] = useState<string | undefined>();
+  const pollAbortController = useRef<AbortController | undefined>(undefined);
+
+  const [userCode, setUserCode] = useState('');
+  const [accessToken, setAccessToken] = useState('');
+
+  // Step 1 (device): start the flow and receive the user code + verification URL to display, plus
+  // the device code used to poll.
+  const requestCode = async (): Promise<void> => {
+    const response = await requestDeviceAuthorization({ deviceLabel });
+    setAuthorization(response);
+    if (response.code === DeviceAuthorizationResponseCode.SUCCESS) {
+      setUserCode(response.userCode ?? ''); // pre-fill step 3, as if read off the screen
+      logger.log('calling [requestDeviceAuthorization]', 'output:', response);
+    } else {
+      logger.error('calling [requestDeviceAuthorization]', 'output:', response);
+    }
+  };
+
+  // Step 2 (device): poll until the user approves on the other device. pollDeviceRefreshToken
+  // honours the server interval and SLOW_DOWN back-off; on SUCCESS it returns the refresh token
+  // (the device's long-lived credential). Access tokens come from step 4.
+  const pollForApproval = async (): Promise<void> => {
+    if (authorization?.deviceCode === undefined) {
+      return;
+    }
+    pollAbortController.current = new AbortController();
+    setIsPolling(true);
+    try {
+      const response = await pollDeviceRefreshToken(authorization.deviceCode, {
+        intervalSeconds: authorization.interval ?? 5,
+        signal: pollAbortController.current.signal,
+        onPending: (pollResponse) =>
+          logger.log('polling [device/poll]', 'output:', pollResponse),
+      });
+      if (response.code === DevicePollResponseCode.SUCCESS) {
+        setRefreshToken(response.refreshToken); // persist this on the device for step 4
+        logger.log('calling [pollDeviceRefreshToken]', 'output:', response);
+      } else {
+        logger.error('calling [pollDeviceRefreshToken]', 'output:', response);
+      }
+    } catch {
+      logger.log('calling [pollDeviceRefreshToken]', 'output: polling stopped');
+    } finally {
+      setIsPolling(false);
+    }
+  };
+
+  const stopPolling = (): void => pollAbortController.current?.abort();
+
+  // Step 3 (activation page): show the signed-in user what the code will authorize.
+  const lookUpCode = async (): Promise<void> => {
+    const response = await getDeviceVerification(userCode);
+    logger.log('calling [getDeviceVerification]', 'output:', response);
+  };
+
+  // Step 3 (activation page): approve or deny on behalf of the signed-in user, identified by
+  // their access token.
+  const approve = async (): Promise<void> => {
+    logger.log(
+      'calling [approveDevice]',
+      'output:',
+      await approveDevice(accessToken, userCode),
+    );
+  };
+
+  const deny = async (): Promise<void> => {
+    logger.log(
+      'calling [denyDevice]',
+      'output:',
+      await denyDevice(accessToken, userCode),
+    );
+  };
+
+  // Step 4 (device): exchange the refresh token for an access token via the standard /token
+  // endpoint. Used for the first access token right after approval, and for every later renewal
+  // (the refresh token is not rotated, so it is reused each time).
+  const getAccessToken = async (): Promise<void> => {
+    if (refreshToken === undefined) {
+      return;
+    }
+    logger.log(
+      'calling [getDeviceAccessToken]',
+      'output:',
+      await getDeviceAccessToken(refreshToken),
+    );
+  };
+
+  return (
+    <Form>
+      <Header size="medium">On the Device</Header>
+      <Form.Input
+        label="Device Label (optional, shown to the user)"
+        value={deviceLabel}
+        onChange={(event) => setDeviceLabel(event.target.value)}
+      />
+      <Button type="button" primary onClick={requestCode}>
+        Step 1: Request a Device Code
+      </Button>
+
+      {authorization?.code === DeviceAuthorizationResponseCode.SUCCESS && (
+        <Segment secondary>
+          <p>
+            User Code: <Label>{authorization.userCode}</Label>
+          </p>
+          <p>
+            Verification URL: <code>{authorization.verificationUri}</code>
+          </p>
+          <p>
+            Expires in {authorization.expiresIn}s · poll every{' '}
+            {authorization.interval}s
+          </p>
+          {authorization.verificationUriComplete !== undefined && (
+            <>
+              <p>
+                Or scan to open the activation page with the code prefilled:
+              </p>
+              {/* verificationUriComplete embeds the user code, so it is rendered
+                  client-side and never sent to an external QR service. */}
+              <QRCode
+                value={authorization.verificationUriComplete}
+                size={160}
+              />
+            </>
+          )}
+        </Segment>
+      )}
+
+      <Button
+        type="button"
+        primary
+        disabled={
+          authorization?.code !== DeviceAuthorizationResponseCode.SUCCESS ||
+          isPolling
+        }
+        loading={isPolling}
+        onClick={pollForApproval}
+      >
+        Step 2: Poll for Approval
+      </Button>
+      {isPolling && (
+        <Button type="button" onClick={stopPolling}>
+          Stop Polling
+        </Button>
+      )}
+
+      <Divider />
+
+      <Header size="medium">On the Activation Page (Signed-In User)</Header>
+      <Form.Input
+        label="User Code"
+        value={userCode}
+        onChange={(event) => setUserCode(event.target.value)}
+      />
+      <Form.Input
+        control={VariableSearch}
+        icon="key"
+        label="Access Token (select the token stored by a Sign-In scenario)"
+        value={accessToken}
+        setStateValue={setAccessToken}
+      />
+      <Button type="button" onClick={lookUpCode}>
+        Step 3: Look Up the Code
+      </Button>
+      <Button type="button" positive onClick={approve}>
+        Approve
+      </Button>
+      <Button type="button" negative onClick={deny}>
+        Deny
+      </Button>
+
+      <Divider />
+      <Header size="medium">On the Device</Header>
+      <Button
+        type="button"
+        disabled={refreshToken === undefined}
+        onClick={getAccessToken}
+      >
+        Step 4: Get an Access Token
+      </Button>
+    </Form>
+  );
+};

--- a/src/scenarios/user-authentication/index.ts
+++ b/src/scenarios/user-authentication/index.ts
@@ -1,3 +1,4 @@
+export * from './DeviceAuthorization/DeviceAuthorization';
 export * from './RenewUserToken/RenewUserToken';
 export * from './ResetPasswordWithAxAuth/ResetPasswordWithAxAuth';
 export * from './ShowUserInfo/ShowUserInfo';

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,11 +81,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@axinom/mosaic-fe-samples-host@npm:0.40.0":
-  version: 0.40.0
-  resolution: "@axinom/mosaic-fe-samples-host@npm:0.40.0"
+"@axinom/mosaic-fe-samples-host@npm:0.43.0-rc.7":
+  version: 0.43.0-rc.7
+  resolution: "@axinom/mosaic-fe-samples-host@npm:0.43.0-rc.7"
   dependencies:
-    "@geoffcox/react-splitter": ^2.1.1
     react-error-boundary: ^3.1.4
   peerDependencies:
     react: ">=17.0.1"
@@ -93,28 +92,30 @@ __metadata:
     react-router-dom: ">=5.2.0"
     semantic-ui-css: ">=2.4.1"
     semantic-ui-react: ">=2.0.3"
-  checksum: 7557d1154acabf138eefe985e7092b5afb7bdd3bf2b8b672b78951156e42972e914ae861f0436b18323e9500a398e271876f806f41e3ee767c329d87f08e5088
+  checksum: 68d7abffcb9ee4f1d47af9324b55bd91100ec3ef097ee8b9c0c59ae7f942699dfded8409caf496140209db207c7ee4819db2900f8e1270a1a5a8ee779d4520c0
   languageName: node
   linkType: hard
 
-"@axinom/mosaic-user-auth-utils@npm:^0.8.28":
-  version: 0.8.28
-  resolution: "@axinom/mosaic-user-auth-utils@npm:0.8.28"
-  checksum: 53d546f0522a7f117618665388823a0638110cf0f2010081fc8cc551456fc149defd8286f514ebc02da4d6b2c7b5ede703f4180f9ae25ed9b2a4556202f025a3
+"@axinom/mosaic-user-auth-utils@npm:0.9.0-rc.0, @axinom/mosaic-user-auth-utils@npm:^0.9.0-rc.0":
+  version: 0.9.0-rc.0
+  resolution: "@axinom/mosaic-user-auth-utils@npm:0.9.0-rc.0"
+  checksum: 8936aa62e8593ae0517cc384e2cdb04fd361542ac26d44275d93180b40aa621e829a789ebd9cae4f68fe8425daa5754240da819e8fe274030dca1c95d1189e4a
   languageName: node
   linkType: hard
 
-"@axinom/mosaic-user-auth@npm:0.26.0":
-  version: 0.26.0
-  resolution: "@axinom/mosaic-user-auth@npm:0.26.0"
+"@axinom/mosaic-user-auth@npm:0.29.0-rc.7":
+  version: 0.29.0-rc.7
+  resolution: "@axinom/mosaic-user-auth@npm:0.29.0-rc.7"
   dependencies:
-    "@axinom/mosaic-user-auth-utils": ^0.8.28
+    "@axinom/mosaic-user-auth-utils": ^0.9.0-rc.0
+    "@graphql-typed-document-node/core": ^3.1.1
+    graphql: ^15.4.0
     graphql-tag: ^2.11.0
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
     react-router-dom: ^5.1.2
-  checksum: 94da1820edc708a89816599e36b86bd9ea9a4151f5b245c1ecee81791fc49d415c167612951f5d4b7bda3bef9cd062e76c7fdd310874bb82dff573ca61336c94
+  checksum: 2264c085edb02f62ff33dd54beaf18a48f08816234ea10b66fe01cba761eca6b7eee95f2c2adb1eb4bac72152ba800420a710e9f34b9dc0d9df15e3b8a3e06d3
   languageName: node
   linkType: hard
 
@@ -1867,7 +1868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.27.0
   resolution: "@babel/runtime@npm:7.27.0"
   dependencies:
@@ -2242,18 +2243,6 @@ __metadata:
     react: ^16.8.0 || ^17 || ^18
     react-dom: ^16.8.0 || ^17 || ^18
   checksum: e63ab044459ef244cbf32840b3abd883e10051e81257873a64a4be8107145a83a7927e5d5da412fd78ffcb55e79cff0d82fcc8bd135fa3c649cb5fbc29e28cfe
-  languageName: node
-  linkType: hard
-
-"@geoffcox/react-splitter@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "@geoffcox/react-splitter@npm:2.1.2"
-  dependencies:
-    react-measure: ^2.5.2
-  peerDependencies:
-    react: ">=16.8.0 <19.0.0"
-    react-dom: ">=16.8.0 <19.0.0"
-  checksum: b1b2b841891c1182788ae5fbc7e774905889eb2d337793ca93436e41a553b5767e547efd5234ea1321026397aa2e14c0c91c2f1ceb13ac09337c4a017ec1634b
   languageName: node
   linkType: hard
 
@@ -8291,13 +8280,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-node-dimensions@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "get-node-dimensions@npm:1.2.2"
-  checksum: 1018db4004ead28c92c02cf5471c3b13572be67cc4dff763c0c7714b8edc370d8020806d3db0400aad87e7e9d3e99635e8582e81636b735a6013051c8e3a4b13
-  languageName: node
-  linkType: hard
-
 "get-own-enumerable-property-symbols@npm:^3.0.0":
   version: 3.0.2
   resolution: "get-own-enumerable-property-symbols@npm:3.0.2"
@@ -8518,6 +8500,13 @@ __metadata:
   peerDependencies:
     graphql: ">=0.11 <=16"
   checksum: 7b622944823fa12a77ea490656121a77e1a1daf08114a6a0b027922113f4481d95f4fe380a5de369a51657ef777d35757dc31f63e41071c21f3e97ca47e4205a
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^15.4.0":
+  version: 15.10.2
+  resolution: "graphql@npm:15.10.2"
+  checksum: 60d14bd5772c2bd20b968c3b544ae7734985b93a018874cdfefee2b479ce07de3f6f54e3fc3324429c0e96b81f477efe9b6e739954e000d00a661136e9091bd5
   languageName: node
   linkType: hard
 
@@ -11034,8 +11023,9 @@ __metadata:
   resolution: "mosaic-frontend-samples@workspace:."
   dependencies:
     "@apollo/client": ^3.2.5
-    "@axinom/mosaic-fe-samples-host": 0.40.0
-    "@axinom/mosaic-user-auth": 0.26.0
+    "@axinom/mosaic-fe-samples-host": 0.43.0-rc.7
+    "@axinom/mosaic-user-auth": 0.29.0-rc.7
+    "@axinom/mosaic-user-auth-utils": 0.9.0-rc.0
     "@babel/core": ^7.16.0
     "@babel/plugin-proposal-private-property-in-object": ^7.21.11
     "@paypal/paypal-js": ^5.1.4
@@ -13056,21 +13046,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-measure@npm:^2.5.2":
-  version: 2.5.2
-  resolution: "react-measure@npm:2.5.2"
-  dependencies:
-    "@babel/runtime": ^7.2.0
-    get-node-dimensions: ^1.2.1
-    prop-types: ^15.6.2
-    resize-observer-polyfill: ^1.5.0
-  peerDependencies:
-    react: ">0.13.0"
-    react-dom: ">0.13.0"
-  checksum: 75bd3cd74d96f3e83f0a42b8f59e8764e6a5eec994492e077c49a4fea0d0b27775a5154502aff2eee3f6af40650ce2e58ed18ac927a64013b14c9942cc9c4872
-  languageName: node
-  linkType: hard
-
 "react-popper@npm:^2.3.0":
   version: 2.3.0
   resolution: "react-popper@npm:2.3.0"
@@ -13354,13 +13329,6 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
-  languageName: node
-  linkType: hard
-
-"resize-observer-polyfill@npm:^1.5.0":
-  version: 1.5.1
-  resolution: "resize-observer-polyfill@npm:1.5.1"
-  checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11091,6 +11091,7 @@ __metadata:
     react-app-polyfill: ^3.0.0
     react-dev-utils: ^12.0.1
     react-dom: ^17.0.1
+    react-qr-code: ^2.0.15
     react-refresh: ^0.11.0
     react-router: ^5.3.4
     react-router-dom: ^5.3.4
@@ -12876,6 +12877,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qrcode-generator@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "qrcode-generator@npm:2.0.4"
+  checksum: d0a212e5126f0fe8f7238cc944f74eed57a8deadf7ec75cf5b052e254ae1fb4487732b0f2e856f3dfbb47e7482b31a9e5cbf3658bbf7fb85624f0dae6a6143e9
+  languageName: node
+  linkType: hard
+
 "qs@npm:~6.14.0":
   version: 6.14.2
   resolution: "qs@npm:6.14.2"
@@ -13074,6 +13082,18 @@ __metadata:
     react: ^16.8.0 || ^17 || ^18
     react-dom: ^16.8.0 || ^17 || ^18
   checksum: 837111c98738011c69b3069a464ea5bdcbf487105b6148e8faf90cb7337e134edb1b98b8824322941c378756cca30a15c18c25f558e53b85ed5762fa0dc8e6b2
+  languageName: node
+  linkType: hard
+
+"react-qr-code@npm:^2.0.15":
+  version: 2.2.0
+  resolution: "react-qr-code@npm:2.2.0"
+  dependencies:
+    prop-types: ^15.8.1
+    qrcode-generator: ^2.0.4
+  peerDependencies:
+    react: "*"
+  checksum: 6bf640c65996d8d12b80c378120ffe5f248919323b3f0a46bbea0d33ffd540748cdd3c822b479ec8b603f36274d52996fc77e83f607bd763a9b4ac66dfa43373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Pull Request

## Prerequisites

- [x] potential **release notes** to the PR description added
- [x] potential **testing notes** to the PR description added
- [ ] appropriate labels for the PR applied

## Description

Adds a **Device Authorization** sample scenario demonstrating sign-in for input-constrained devices (e.g. smart TVs) against the Mosaic user-service, and brings all `@axinom/mosaic-*` libraries up to their latest RC so the scenario resolves the published SDK (device methods/types) rather than a local link.

The scenario walks through the full flow in one screen (playing both roles):

1. **Device** requests a device code and displays the user code + verification URL (with a QR code for the code-prefilled activation link).
2. **Device** polls for approval, honouring the server interval and `SLOW_DOWN` back-off; on success it receives the refresh token.
3. **Activation page** (a signed-in user) looks up the code and approves/denies it.
4. **Device** exchanges the refresh token for an access token via the standard `/token` endpoint.

### Release notes

- New scenario: **Device Authorization (Smart-TV Sign-In)** under User Authentication.

### Testing notes

- `yarn build` passes cleanly (no device-related warnings/errors).
- To exercise the scenario end-to-end you need a user-service with the device authorization endpoints and both a NATIVE application (the device) and a WEB application (the activation page) sharing the same user store. Run a Sign-In scenario first to obtain an access token for step 3 (approve/deny).